### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM node:boron
 
-RUN mkdir -p /usr/src/app
+#Diretorio que o apicativo vai rodar
+WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app
+#Copia o arquivo de dependencias pro workdir
+COPY . .
 
+#Instala os paranaue
 RUN npm install
 
-COPY . /usr/src/app
+#Abre a porta 8080
+EXPOSE 3000
 
-EXPOSE 8080
+#Roda o comando de start do package.json
 CMD [ "npm", "start" ]


### PR DESCRIPTION
This Dockerfile version fixes:

- Should use `WORKDIR`
- Copy all project to work directory(not by steps)
- Executes `npm install` from the right directory(work directory)
- Expose 3000 PORT (is port used in `server.js`

You should build the image running `docker build -t {IMAGE_NAME}:{VERSION} .`

You should run your image runnig `docker run --name {CONTAINER_NAME} -p {EXTERNAL_PORT}:3000 {IMAGE_NAME}:{VERSION}`